### PR TITLE
Rapidsnark build for different targets

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -5,9 +5,6 @@ description: Install stable toolchain fo Rust
 runs:
   using: composite
   steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-
     - name: Cache
       uses: Swatinem/rust-cache@v2
 

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -1,0 +1,18 @@
+name: "Rust setup"
+
+description: Install stable toolchain fo Rust
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install stable toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: "rustfmt, clippy"
+        toolchain: 1.75.0

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,6 +16,9 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
       - name: Rust setup
         uses: ./.github/actions/rust-setup
 
@@ -36,6 +39,9 @@ jobs:
     name: Check Documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
       - name: Rust setup
         uses: ./.github/actions/rust-setup
 
@@ -50,6 +56,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
       - name: Rust setup
         uses: ./.github/actions/rust-setup
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,17 +16,8 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: "rustfmt, clippy"
-          toolchain: 1.75.0
+      - name: Rust setup
+        uses: ./.github/actions/rust-setup
 
       - name: Run cargo check
         run: cargo check
@@ -45,14 +36,25 @@ jobs:
     name: Check Documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Rust setup
+        uses: ./.github/actions/rust-setup
 
       - name: Run cargo doc
         run: cargo doc --no-deps
+
+  build:
+    needs: [lints, doctests]
+    name: Build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Rust setup
+        uses: ./.github/actions/rust-setup
+
+      - name: Run cargo build
+        run: cargo build
+
+      - name: Run cargo build on release version
+        run: cargo build --release

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -62,6 +62,12 @@ jobs:
       - name: Rust setup
         uses: ./.github/actions/rust-setup
 
+      - name: Install OpenMP to link for rapidnsark on ubuntu-latest
+        if: ${{ matrix.os == ubuntu-latest }}
+        run: |
+          sudo apt update && sudo apt upgrade
+          sudo apt install libomp-dev
+
       - name: Run cargo build
         run: cargo build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-target"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +2909,9 @@ dependencies = [
 [[package]]
 name = "rapidsnark-sys"
 version = "0.1.0"
+dependencies = [
+ "build-target",
+]
 
 [[package]]
 name = "rayon"

--- a/crates/rapidsnark-sys/Cargo.toml
+++ b/crates/rapidsnark-sys/Cargo.toml
@@ -2,3 +2,6 @@
 name    = "rapidsnark-sys"
 version = "0.1.0"
 edition = "2021"
+
+[build-dependencies]
+build-target = { version = "0.4.0" }

--- a/crates/rapidsnark-sys/build.rs
+++ b/crates/rapidsnark-sys/build.rs
@@ -1,6 +1,10 @@
+use build_target::{Arch, Os};
 use std::env;
 
 fn main() {
+    let target_arch = build_target::target_arch().unwrap();
+    let target_os = build_target::target_os().unwrap();
+
     // Determine the directory where build.rs and Cargo.toml reside
     let dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
@@ -10,10 +14,38 @@ fn main() {
     // Specify the paths to the static libraries
     println!("cargo:rustc-link-search=native={}", path);
 
-    // Tell cargo to link with these static libraries
-    println!("cargo:rustc-link-lib=static=rapidsnark-darwin-arm64");
-    println!("cargo:rustc-link-lib=static=gmp-darwin-arm64");
+    let os_suffix = match target_os {
+        Os::MacOs => {
+            // Link with the C++ standard library
+            println!("cargo:rustc-link-lib=c++");
 
-    // Link with the C++ standard library
-    println!("cargo:rustc-link-lib=c++");
+            "darwin"
+        }
+        _ => {
+            // Link with the C++ standard library
+            println!("cargo:rustc-link-lib=stdc++");
+
+            "linux"
+        }
+    };
+
+    let arch_suffix = match target_arch {
+        Arch::X86_64 => {
+            // Link with OpenMP
+            println!("cargo:rustc-link-lib=omp");
+
+            "amd64"
+        }
+        Arch::AARCH64 => "arm64",
+        _ => panic!("Unsupported architecture: {}", target_arch),
+    };
+
+    println!(
+        "cargo:rustc-link-lib=static=rapidsnark-{}-{}",
+        os_suffix, arch_suffix
+    );
+    println!(
+        "cargo:rustc-link-lib=static=gmp-{}-{}",
+        os_suffix, arch_suffix
+    );
 }


### PR DESCRIPTION
# Changes
- Add the linking of the vendored rapidsnark files in the `build.rs` for `rapidsnark-sys` crate
- Add the `rust-setup` action to install the Rust toolchain
- Add `cargo build` job to the workflow with `matrix` for different OSs